### PR TITLE
Removed heap limit by recalculating the maxbrk value from the current stack pointer with each call to _sbrk().

### DIFF
--- a/libpic32/stubs/sbrk.c
+++ b/libpic32/stubs/sbrk.c
@@ -236,7 +236,7 @@ _sbrk_init (void)
     else {
 	/* kuseg: use virtual addresses */
 	_minbrk = (void *) min;
-	_minbrk = (void *) max;
+	_maxbrk = (void *) max;
     }
     
     curbrk = _minbrk;
@@ -267,7 +267,7 @@ static inline void calculate_maxbrk() {
         _maxbrk = PA_TO_KVA0 (max);
     } else {
         /* kuseg: use virtual addresses */
-        _minbrk = (void *) max;
+        _maxbrk = (void *) max;
     }
 }
 


### PR DESCRIPTION
Instead of limiting the heap to just 2kB (or whatever happens to be in the linker script), this change recalculates what the current maximum heap could be (`maxbrk`) each time `_sbrk()` is called. It takes the current stack pointer, subtracts 1024 as a margin of safety, and uses that for the maximum heap space allowed.

This should minimise stack smashing since the heap should not be able to grow into the stack. However the stack can grown into the heap.